### PR TITLE
Fixed: cancel returns value, stauts to status

### DIFF
--- a/controllers/attendances_controller.rb
+++ b/controllers/attendances_controller.rb
@@ -26,7 +26,7 @@ class Protect < Sinatra::Base
       attendance[0].destroy
       {status: "succeeded"}.to_json
     else
-      {stauts: "failed"}.to_json
+      {status: "failed"}.to_json
     end
   end
 


### PR DESCRIPTION
エラーの時に `status` が `null` だからおかしいなと思ったらこれですよ！！